### PR TITLE
Install Spectrum in themes subdirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Installation
 
 From your site root:
 
-    git submodule add git@github.com:silvanocerza/spectrum.git
+    git submodule add git@github.com:silvanocerza/spectrum.git themes/spectrum
     git submodule update --init --recursive
 
 Set the theme in your site config:


### PR DESCRIPTION
The existing instructions won't actually work; the theme needs to be installed in the themes/ subdirectory.